### PR TITLE
Neo4j stability: Recreate strategy + exec probes + heap split + memory request (downtime)

### DIFF
--- a/helm/echo/templates/deployment-neo4j.yaml
+++ b/helm/echo/templates/deployment-neo4j.yaml
@@ -7,6 +7,8 @@ metadata:
     component: neo4j
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: echo
@@ -29,6 +31,8 @@ spec:
           env:
             - name: NEO4J_AUTH
               value: "neo4j/{{ .Values.neo4j.password }}"
+            - name: NEO4J_PASSWORD
+              value: "{{ .Values.neo4j.password }}"
             - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
               value: "yes"
             - name: NEO4J_server_logs_console_enabled
@@ -36,9 +40,17 @@ spec:
             - name: NEO4J_server_memory_pagecache_size
               value: "{{ .Values.neo4j.config.pagecacheSize | default "512M" }}"
             - name: NEO4J_server_memory_heap_initial__size
-              value: "{{ .Values.neo4j.config.heapSize | default "512M" }}"
+              value: "{{ default (default "512M" .Values.neo4j.config.heapSize) .Values.neo4j.config.heapInitialSize }}"
             - name: NEO4J_server_memory_heap_max__size
-              value: "{{ .Values.neo4j.config.heapSize | default "512M" }}"
+              value: "{{ default (default "512M" .Values.neo4j.config.heapSize) .Values.neo4j.config.heapMaxSize }}"
+            - name: NEO4J_server_bolt_listen__address
+              value: "0.0.0.0:7687"
+            - name: NEO4J_server_bolt_thread__pool_min__size
+              value: "{{ .Values.neo4j.config.boltThreadPoolMin | default "10" }}"
+            - name: NEO4J_server_bolt_thread__pool_max__size
+              value: "{{ .Values.neo4j.config.boltThreadPoolMax | default "400" }}"
+            - name: NEO4J_server_bolt_backlog__size
+              value: "{{ .Values.neo4j.config.boltBacklogSize | default "1024" }}"
           volumeMounts:
             - name: neo4j-data
               mountPath: /data
@@ -50,15 +62,25 @@ spec:
               cpu: "{{ .Values.neo4j.resources.limits.cpu | default "1000m" }}"
               memory: "{{ .Values.neo4j.resources.limits.memory | default "2Gi" }}"
           readinessProbe:
-            tcpSocket:
-              port: 7687
+            exec:
+              command:
+                - /bin/sh
+                - -lc
+                - 'echo "RETURN 1;" | /var/lib/neo4j/bin/cypher-shell -a bolt://localhost:7687 -u neo4j -p "$NEO4J_PASSWORD" >/dev/null'
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           livenessProbe:
-            tcpSocket:
-              port: 7687
+            exec:
+              command:
+                - /bin/sh
+                - -lc
+                - 'echo "RETURN 1;" | /var/lib/neo4j/bin/cypher-shell -a bolt://localhost:7687 -u neo4j -p "$NEO4J_PASSWORD" >/dev/null'
             initialDelaySeconds: 60
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: neo4j-data
           persistentVolumeClaim:

--- a/helm/echo/values-prod.yaml
+++ b/helm/echo/values-prod.yaml
@@ -126,11 +126,12 @@ neo4j:
     size: "40Gi"
   config:
     pagecacheSize: "2G"
-    heapSize: "4G"
+    heapInitialSize: "2G"
+    heapMaxSize: "4G"
   resources:
     requests:
       cpu: "1"
-      memory: "1Gi"
+      memory: "7Gi"
     limits:
       cpu: "4"
       memory: "8Gi"


### PR DESCRIPTION
CAUTION: Merging will cause brief downtime (about 1–3 min) due to Recreate strategy with a single-replica RWO PVC. Changes: Recreate rollout, exec liveness/readiness via cypher-shell, split heap initial/max, raise prod memory requests to 7Gi, add Bolt tuning. Recommend merging during low-traffic window.