### PR TITLE
fix(argocd): echo-prod tracks main

### DIFF
--- a/argo/echo-prod.yaml
+++ b/argo/echo-prod.yaml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: 'https://github.com/dembrane/echo-gitops.git'
-    targetRevision: feature/monitoring_prod
+    targetRevision: main
     path: helm/echo
     helm:
       valueFiles:


### PR DESCRIPTION
Switch echo-prod ArgoCD Application to track main so prod receives merged changes (PR #6) via helm/echo. Safe to sync: no resource deletions expected; only source revision change. After merge: watch prod rollout for echo-neo4j and app workloads.