### PR TITLE
Enable agentic chat on echo-next

### DIFF
--- a/helm/echo/templates/deployment-agent.yaml
+++ b/helm/echo/templates/deployment-agent.yaml
@@ -43,6 +43,11 @@ spec:
                 secretKeyRef:
                   name: echo-backend-secrets
                   key: GEMINI_API_KEY
+            - name: GCP_SA_JSON
+              valueFrom:
+                secretKeyRef:
+                  name: echo-backend-secrets
+                  key: GCP_SA_JSON
 {{- range $name, $value := .Values.agent.env }}
             - name: {{ $name }}
               value: {{ $value | quote }}

--- a/helm/echo/values.yaml
+++ b/helm/echo/values.yaml
@@ -11,6 +11,7 @@ common:
     ADMIN_BASE_URL: "https://dashboard.echo-next.dembrane.com"
     PARTICIPANT_BASE_URL: "https://portal.echo-next.dembrane.com"
     API_BASE_URL: "https://api.echo-next.dembrane.com/api"
+    AGENT_SERVICE_URL: "http://echo-agent:8001"
     DISABLE_CORS: "0"
     DISABLE_REDACTION: "1"
     DISABLE_SENTRY: "0"
@@ -69,7 +70,7 @@ apiServer:
       memory: "2.5Gi"
 
 agent:
-  enabled: false
+  enabled: true
   replicaCount: 1
   image:
     repository: "dbr-echo-agent"
@@ -84,8 +85,10 @@ agent:
       memory: "1Gi"
   env:
     ECHO_API_URL: "http://echo-api:8000/api"
+    LLM_MODEL: "claude-opus-4-6"
+    VERTEX_LOCATION: "europe-west1"
     AGENT_GRAPH_RECURSION_LIMIT: "80"
-    AGENT_CORS_ORIGINS: "http://localhost:5173,http://localhost:5174"
+    AGENT_CORS_ORIGINS: "https://dashboard.echo-next.dembrane.com,https://portal.echo-next.dembrane.com,http://localhost:5173,http://localhost:5174"
 
 worker:
   replicaCount: 1


### PR DESCRIPTION
## Summary
- enable the existing echo-agent deployment path on echo-next
- point the staging API at the in-cluster agent service
- inject the GCP service account JSON into the agent pod so Vertex-backed agentic chat can run

## Changes
- set `AGENT_SERVICE_URL` in `helm/echo/values.yaml`
- enable `agent.enabled` for echo-next
- add `LLM_MODEL=claude-opus-4-6` and `VERTEX_LOCATION=europe-west1` to the staging agent env
- expand `AGENT_CORS_ORIGINS` for the echo-next dashboard and portal
- add `GCP_SA_JSON` to the agent deployment from `echo-backend-secrets`

## Validation
- rendered the chart with `docker run --rm -v /tmp/echo-next-agentic-chat:/work -w /work alpine/helm:3.16.4 template echo ./helm/echo -f ./helm/echo/values.yaml`
- verified the rendered manifests include:
  - `echo-agent` Deployment and Service
  - `AGENT_SERVICE_URL=http://echo-agent:8001` on the API deployment
  - `GCP_SA_JSON` on the agent deployment
  - `LLM_MODEL=claude-opus-4-6` and `VERTEX_LOCATION=europe-west1` on the agent deployment

## Follow-up
- after this merges, set `VITE_ENABLE_AGENTIC_CHAT=1` manually in the staging Vercel env for dashboard and portal, then redeploy those apps