### PR TITLE
fix(monitoring): tighten grafana log panel regex (ECHO-815)

### DIFF
--- a/helm/monitoring/templates/configmap-grafana-dashboards.yaml
+++ b/helm/monitoring/templates/configmap-grafana-dashboards.yaml
@@ -1036,7 +1036,7 @@ data:
           },
           "targets": [
             {
-              "expr": "{namespace=~\"echo-.*\"} |~ \"error|ERROR|Error|Exception|exception|EXCEPTION\""
+              "expr": "{namespace=~\"echo-.*\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""
             }
           ],
           "options": {
@@ -1233,13 +1233,13 @@ data:
           "fieldConfig": {"defaults": {"unit": "short"}},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"api\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\")[5m]))"}
+            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"api\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\")[5m]))"}
           ]
         },
         {"type": "logs", "title": "API Error Logs", "id": 202, "gridPos": {"h": 8, "w": 18, "x": 6, "y": 36},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"api\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\""}
+            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"api\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""}
           ],
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true}
         },
@@ -1247,13 +1247,13 @@ data:
           "fieldConfig": {"defaults": {"unit": "short"}},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"directus\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\")[5m]))"}
+            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"directus\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\")[5m]))"}
           ]
         },
         {"type": "logs", "title": "Directus Error Logs", "id": 204, "gridPos": {"h": 8, "w": 18, "x": 6, "y": 44},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"directus\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\""}
+            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"directus\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""}
           ],
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true}
         },
@@ -1261,13 +1261,13 @@ data:
           "fieldConfig": {"defaults": {"unit": "short"}},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"worker\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\")[5m]))"}
+            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"worker\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\")[5m]))"}
           ]
         },
         {"type": "logs", "title": "Worker Error Logs", "id": 206, "gridPos": {"h": 8, "w": 18, "x": 6, "y": 52},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"worker\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\""}
+            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"worker\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""}
           ],
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true}
         },
@@ -1275,13 +1275,13 @@ data:
           "fieldConfig": {"defaults": {"unit": "short"}},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"worker-cpu\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\")[5m]))"}
+            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", component=\"worker-cpu\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\")[5m]))"}
           ]
         },
         {"type": "logs", "title": "Worker-CPU Error Logs", "id": 208, "gridPos": {"h": 8, "w": 18, "x": 6, "y": 60},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"worker-cpu\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\""}
+            {"refId": "A", "expr": "{namespace=\"echo-prod\", component=\"worker-cpu\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""}
           ],
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true}
         }
@@ -1290,13 +1290,13 @@ data:
           "fieldConfig": {"defaults": {"unit": "short"}},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", container=\"neo4j\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\")[5m]))"}
+            {"refId": "A", "expr": "sum(count_over_time(({namespace=\"echo-prod\", container=\"neo4j\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\")[5m]))"}
           ]
         },
         {"type": "logs", "title": "Neo4j Error Logs", "id": 210, "gridPos": {"h": 8, "w": 18, "x": 6, "y": 68},
           "datasource": {"type": "loki", "uid": "loki"},
           "targets": [
-            {"refId": "A", "expr": "{namespace=\"echo-prod\", container=\"neo4j\"} |~ \"(?i)(error|exception|fail|fatal|critical|panic|warn|warning)\""}
+            {"refId": "A", "expr": "{namespace=\"echo-prod\", container=\"neo4j\"} |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""}
           ],
           "options": {"dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": true}
         }
@@ -1805,12 +1805,12 @@ data:
               {
                 "selected": false,
                 "text": "Error Logs",
-                "value": "|~ \"(?i)error|exception|fail|fatal\""
+                "value": "|~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\""
               },
               {
                 "selected": false,
                 "text": "Warning Logs",
-                "value": "|~ \"(?i)warn|warning\""
+                "value": "|~ \"\\\\b(WARN|WARNING)\\\\b|\\\\[(warn|warning)\\\\]\""
               },
               {
                 "selected": false,
@@ -1818,7 +1818,7 @@ data:
                 "value": "|~ \"worker-cpu\""
               }
             ],
-            "query": "All Logs : ,Error Logs : |~ \"(?i)error|exception|fail|fatal\",Warning Logs : |~ \"(?i)warn|warning\",Worker CPU Logs : |~ \"worker-cpu\"",
+            "query": "All Logs : ,Error Logs : |~ \"\\\\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\\\\b|\\\\[(error|fatal|critical)\\\\]\",Warning Logs : |~ \"\\\\b(WARN|WARNING)\\\\b|\\\\[(warn|warning)\\\\]\",Worker CPU Logs : |~ \"worker-cpu\"",
             "skipUrlSync": false,
             "type": "custom"
           },


### PR DESCRIPTION
Closes the substring false-positive problem on Grafana log panels described in [ECHO-815](https://linear.app/dembrane/issue/ECHO-815).

## What changes

Replace the substring regex used in all log panels:

```
(?i)(error|exception|fail|fatal|critical|panic|warn|warning)
```

with level-anchored patterns:

* **Error panels** — `\b(ERROR|FATAL|CRITICAL|Exception|Traceback)\b|\[(error|fatal|critical)\]`
* **Warning panels** — `\b(WARN|WARNING)\b|\[(warn|warning)\]`

Touches 14 places in `configmap-grafana-dashboards.yaml`:

* 10 per-service "Error Logs" queries (api / directus / worker / worker-cpu / neo4j × 2 panels)
* 1 "Echo Application Error Logs" panel
* 2 `logfilter` variable values + 1 query string

## Why this drops the noise

`_` is a word character in RE2. `\berror\b` does NOT match inside `transcript_error` / `latest_error` / `latest_error_code` — directus's loudest column-name offenders disappear without exclusion lists.

`ERROR|FATAL|CRITICAL` is case-sensitive on purpose: matches python `logging` level prefixes (confirmed: echo server uses standard `logging.getLogger(...)`). `Exception` / `Traceback` covers tracebacks. `\[(error|fatal|critical)\]` covers nginx-style bracketed lowercase.

## What this drops that you might miss

* Lowercase mentions of "error" inside log bodies at non-error levels (e.g. an `INFO` line that talks about an error). Mostly low-signal.
* Custom log formats not using one of these tokens. None found in the echo codebase.

The real fix (`promtail` JSON pipeline → extract `level` as a label → panels filter on `{level=~"error|fatal|critical"}`) supersedes this. Filed in ECHO-815 as a follow-up.

## Verification

Locally JSON-parsed each changed `expr` string and ran the inner regex against sample log lines:

| line | matches |
|---|---|
| `ERROR: kafka conn refused` | yes |
| `Exception in thread main` | yes |
| `nginx [error] 502 bad gateway` | yes |
| `INFO: latest_error column was null` | **no** |
| `INFO: transcript_error field updated` | **no** |
| `INFO accessing /api/transcript_errors?id=42` | **no** |
| `WARNING: slow query` | no (handled by warning panel) |

Helm not installed locally so couldn't render the full template — the changes are pure data inside a block scalar, no template substitution touched.

## Confidence

Medium-high. The change is mechanical and the regex was verified against the directus-column false-positives. The unknown is panel-level UX: warning panels now only show WARN/WARNING (instead of also catching the bottom of the error spectrum). If that turns out to be wrong, easy follow-up.

Refs: ECHO-815