### PR TITLE
feat(monitoring): split alertmanager routes by severity + raise latency thresholds (ECHO-813)

### DIFF
--- a/helm/monitoring/templates/alertmanager.yaml
+++ b/helm/monitoring/templates/alertmanager.yaml
@@ -13,8 +13,33 @@ data:
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 2h
-      receiver: 'slack-prod'
+      # Default: drop. Only alerts that explicitly match a child route are
+      # routed elsewhere. This makes "did I forget to label this alert?"
+      # a silent dev-time bug rather than a 3am page.
+      receiver: 'blackhole'
+      routes:
+        # Watchdog: always-firing canary. Routed to null so it never pages,
+        # but still visible in the alertmanager UI. A future dead-man's-switch
+        # consumer can poll the API for this alert to confirm the pipeline
+        # is alive.
+        - matchers:
+            - alertname = "Watchdog"
+          receiver: 'blackhole'
+          continue: false
+        # Critical alerts -> #prod-alerts (current behaviour)
+        - matchers:
+            - severity = "critical"
+          receiver: 'slack-prod'
+          continue: false
+        # Warning alerts -> null receiver (visible in alertmanager UI for
+        # debugging, no slack notification). Discoverability via weekly
+        # digest (ECHO-817).
+        - matchers:
+            - severity = "warning"
+          receiver: 'blackhole'
+          continue: false
     receivers:
+      - name: 'blackhole'
       - name: 'slack-prod'
         slack_configs:
           - channel: '#prod-alerts'

--- a/helm/monitoring/templates/configmap-prometheus.yaml
+++ b/helm/monitoring/templates/configmap-prometheus.yaml
@@ -295,23 +295,32 @@ data:
           summary: "Critical error rate via ingress on {{ "{{" }} $labels.svc {{ "}}" }}"
           description: "5xx ratio > 20% over 5m: {{ "{{" }} $value {{ "}}" }}"
 
+      # Latency thresholds raised from 0.5s/10m -> 1s/15m (warning) and
+      # 1.5s/5m -> 3s/10m (critical) per ECHO-813. Starting values; tune
+      # once we have p95 distribution data from the cluster.
+      #
+      # Note: nginx_ingress_controller_request_duration_seconds is bucketed
+      # by `svc` (service-level), not by path. Long-tail endpoints
+      # (transcription, LLM streaming) get aggregated into the `api` svc's
+      # p95 and can drag it up. Path-level alerting would need a route
+      # label that isn't currently extracted — separate follow-up.
       - alert: IngressHighLatencyP95
-        expr: histogram_quantile(0.95, sum by (svc, le) ( label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "exported_service", "(.*)") or label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "service", "(.*)") )) > 0.5
-        for: 10m
+        expr: histogram_quantile(0.95, sum by (svc, le) ( label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "exported_service", "(.*)") or label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "service", "(.*)") )) > 1
+        for: 15m
         labels:
           severity: warning
         annotations:
           summary: "High p95 latency via ingress on {{ "{{" }} $labels.svc {{ "}}" }}"
-          description: "> 0.5s over 10m: {{ "{{" }} $value {{ "}}" }}"
+          description: "> 1s over 15m: {{ "{{" }} $value {{ "}}" }}"
 
       - alert: IngressCriticalLatencyP95
-        expr: histogram_quantile(0.95, sum by (svc, le) ( label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "exported_service", "(.*)") or label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "service", "(.*)") )) > 1.5
-        for: 5m
+        expr: histogram_quantile(0.95, sum by (svc, le) ( label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "exported_service", "(.*)") or label_replace(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace="echo-prod"}[5m]), "svc", "$1", "service", "(.*)") )) > 3
+        for: 10m
         labels:
           severity: critical
         annotations:
           summary: "Critical p95 latency via ingress on {{ "{{" }} $labels.svc {{ "}}" }}"
-          description: "> 1.5s over 5m: {{ "{{" }} $value {{ "}}" }}"
+          description: "> 3s over 10m: {{ "{{" }} $value {{ "}}" }}"
 
       - alert: CrashLoopBackOff
         expr: sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="echo-prod"}) > 0
@@ -365,3 +374,17 @@ data:
         annotations:
           summary: "Unavailable replicas for {{ "{{" }} $labels.deployment {{ "}}" }}"
           description: "Available replicas < desired for 10m. Check rollout status, image pulls, probes, and node capacity."
+
+    - name: pipeline
+      rules:
+      # Always-firing canary that confirms prometheus is evaluating rules
+      # and alertmanager is receiving them. Routed to a null receiver in
+      # alertmanager so it never pages — a future dead-man's-switch
+      # consumer can poll the alertmanager API for its presence.
+      - alert: Watchdog
+        expr: vector(1)
+        labels:
+          severity: none
+        annotations:
+          summary: "Alerting pipeline is alive"
+          description: "Canary alert. Absence indicates prometheus or alertmanager is broken."


### PR DESCRIPTION
Closes the noise/dropped-alerts split described in [ECHO-813](https://linear.app/dembrane/issue/ECHO-813).

## Three changes

### 1. Alertmanager route tree

- **Default receiver** is now `blackhole` (no notification). An unlabelled alert silently drops instead of paging.
- `severity=critical` → `slack-prod` → `#prod-alerts` (unchanged behaviour for crit).
- `severity=warning` → `blackhole`. Visible in alertmanager UI, no Slack. Discoverability via the weekly digest from #ECHO-817.
- `alertname=Watchdog` → `blackhole`. Always-firing canary, never pages.

### 2. Latency thresholds

| Alert | Old | New |
|---|---|---|
| IngressHighLatencyP95 (warning) | 0.5s for 10m | **1s for 15m** |
| IngressCriticalLatencyP95 (critical) | 1.5s for 5m | **3s for 10m** |

These are starting values. The ticket flagged that real numbers should come from the actual p95 distribution over 7d. I don't have prometheus access from where I run, so couldn't pull that — happy to re-tune from a query you run.

Path-level exclusion (transcription, LLM streaming) needs a route label that isn't currently extracted from the ingress metric. Filed as a follow-up note in the rule comment rather than added here.

### 3. Watchdog alert

New `pipeline` rule group with `vector(1)` always-firing canary, `severity: none`. Routed to `blackhole` so it never notifies; a future dead-man's-switch consumer can poll the alertmanager API for its presence.

## Severity audit

Every existing alert has an explicit `severity: warning` or `severity: critical`. No mislabels. The audit was:

| Alert | severity |
|---|---|
| HighNodeCPU, HighNodeMemory, NodeDiskFillingSoon | warning |
| IngressHighErrorRate, IngressHighLatencyP95 | warning |
| IngressCriticalErrorRate, IngressCriticalLatencyP95 | critical |
| CrashLoopBackOff, OOMKilled, DeploymentAvailabilityShortfall | critical |
| PodRestartSpike, HighContainerCPUUtilization, HighContainerMemoryUtilization | warning |

## Verification

- alertmanager.yml parses with python-yaml; route tree resolves all referenced receivers.
- Latency-rule YAML structure parses cleanly.
- `amtool check-config` / `promtool check rules` not available locally. CI should run them; if it doesn't, flagging that we should add it.

## Confidence

Medium. Routing logic is straightforward and matches alertmanager's documented matcher syntax. Watchdog is the canonical Prometheus example. The thresholds are educated guesses — if you have the 7d p95 numbers, I'd rather use those.

Refs: ECHO-813