### PR TITLE
fix(api): add startupProbe to prevent crash-loop on slow boot

### DIFF
--- a/helm/echo/templates/deployment-api-server.yaml
+++ b/helm/echo/templates/deployment-api-server.yaml
@@ -49,6 +49,17 @@ spec:
               cpu: {{ .Values.apiServer.resources.limits.cpu | quote }}
               memory: {{ .Values.apiServer.resources.limits.memory | quote }}
 
+          # Startup can be slow (image rebuilds its uv venv on first boot),
+          # which previously tripped the liveness probe into a crash loop.
+          # startupProbe gives up to ~5m to come up before liveness applies.
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 30
+
           readinessProbe:
             httpGet:
               path: /api/health
@@ -58,7 +69,7 @@ spec:
             timeoutSeconds: 15
             successThreshold: 1
             failureThreshold: 3
-          
+
           livenessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
The api image rebuilds its uv venv on first boot, which can exceed the liveness probe window and kill the pod before it serves, crash-looping the rollout (seen on echo-next). Adds a startupProbe (up to ~5m) that defers liveness/readiness until the app is up. No effect on fast-starting pods (prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)