### PR TITLE
fix(echo-next): EU-resident Gemini 3.5 Flash via api_base override

### DIFF
--- a/helm/echo/templates/_helpers.tpl
+++ b/helm/echo/templates/_helpers.tpl
@@ -56,6 +56,10 @@ Common environment variables (including feature flags and non-sensitive config)
 - name: LLM__MULTI_MODAL_PRO__VERTEX_LOCATION
   value: {{ . | quote }}
 {{- end }}
+{{- with (default "" .Values.common.env.LLM__MULTI_MODAL_PRO__API_BASE) }}
+- name: LLM__MULTI_MODAL_PRO__API_BASE
+  value: {{ . | quote }}
+{{- end }}
 {{- with (default "" .Values.common.env.LLM__MULTI_MODAL_FAST__MODEL) }}
 - name: LLM__MULTI_MODAL_FAST__MODEL
   value: {{ . | quote }}
@@ -64,12 +68,20 @@ Common environment variables (including feature flags and non-sensitive config)
 - name: LLM__MULTI_MODAL_FAST__VERTEX_LOCATION
   value: {{ . | quote }}
 {{- end }}
+{{- with (default "" .Values.common.env.LLM__MULTI_MODAL_FAST__API_BASE) }}
+- name: LLM__MULTI_MODAL_FAST__API_BASE
+  value: {{ . | quote }}
+{{- end }}
 {{- with (default "" .Values.common.env.LLM__TEXT_FAST__MODEL) }}
 - name: LLM__TEXT_FAST__MODEL
   value: {{ . | quote }}
 {{- end }}
 {{- with (default "" .Values.common.env.LLM__TEXT_FAST__VERTEX_LOCATION) }}
 - name: LLM__TEXT_FAST__VERTEX_LOCATION
+  value: {{ . | quote }}
+{{- end }}
+{{- with (default "" .Values.common.env.LLM__TEXT_FAST__API_BASE) }}
+- name: LLM__TEXT_FAST__API_BASE
   value: {{ . | quote }}
 {{- end }}
 {{- with (default "" .Values.common.env.LLM__TEXT_FAST_2__MODEL) }}

--- a/helm/echo/values-echo-next.yaml
+++ b/helm/echo/values-echo-next.yaml
@@ -4,14 +4,23 @@
 # for echo-next without touching prod/testing (which do not reference this file).
 #
 # Swaps all three LLM groups (multimodal pro, multimodal fast, text fast) to
-# Gemini 3.5 Flash on Vertex in the EU multi-region. 3.5 Flash is verified on
-# "eu" (see spashii config, 2026-05-20); it is not in the specific europe-west
-# zones the shared config used, so the _2/_3 regional failovers are disabled
-# (empty model => the env helper skips them => not registered as deployments).
+# Gemini 3.5 Flash on Vertex, EU-resident.
+#
+# Gemini 3.x is only served on the GLOBAL Vertex hostname
+# (aiplatform.googleapis.com), not the regional eu-aiplatform.googleapis.com
+# host that litellm builds for vertex_location=eu (that 404s). So we pin
+# API_BASE to the global host while keeping locations/eu in the path: the
+# request is served by Gemini 3 yet processed in the EU multi-region. Verified
+# locally against the dembrane-echo project (2026-06-05).
+#
+# The api_base hardcodes project + model because litellm appends ":generateContent"
+# to it verbatim. This file is echo-next-only, so the dembrane-echo project is correct.
+# The _2/_3 regional failovers stay disabled (3.5 Flash is global-host only).
 common:
   env:
     LLM__MULTI_MODAL_PRO__MODEL: "vertex_ai/gemini-3.5-flash"
     LLM__MULTI_MODAL_PRO__VERTEX_LOCATION: "eu"
+    LLM__MULTI_MODAL_PRO__API_BASE: "https://aiplatform.googleapis.com/v1/projects/dembrane-echo/locations/eu/publishers/google/models/gemini-3.5-flash"
     LLM__MULTI_MODAL_PRO_2__MODEL: ""
     LLM__MULTI_MODAL_PRO_2__VERTEX_LOCATION: ""
     LLM__MULTI_MODAL_PRO_3__MODEL: ""
@@ -19,6 +28,7 @@ common:
 
     LLM__MULTI_MODAL_FAST__MODEL: "vertex_ai/gemini-3.5-flash"
     LLM__MULTI_MODAL_FAST__VERTEX_LOCATION: "eu"
+    LLM__MULTI_MODAL_FAST__API_BASE: "https://aiplatform.googleapis.com/v1/projects/dembrane-echo/locations/eu/publishers/google/models/gemini-3.5-flash"
     LLM__MULTI_MODAL_FAST_2__MODEL: ""
     LLM__MULTI_MODAL_FAST_2__VERTEX_LOCATION: ""
     LLM__MULTI_MODAL_FAST_3__MODEL: ""
@@ -26,6 +36,7 @@ common:
 
     LLM__TEXT_FAST__MODEL: "vertex_ai/gemini-3.5-flash"
     LLM__TEXT_FAST__VERTEX_LOCATION: "eu"
+    LLM__TEXT_FAST__API_BASE: "https://aiplatform.googleapis.com/v1/projects/dembrane-echo/locations/eu/publishers/google/models/gemini-3.5-flash"
     LLM__TEXT_FAST_2__MODEL: ""
     LLM__TEXT_FAST_2__VERTEX_LOCATION: ""
     LLM__TEXT_FAST_3__MODEL: ""


### PR DESCRIPTION
gemini-3.5-flash @ eu 404'd because litellm builds eu-aiplatform.googleapis.com, but Gemini 3.x is global-host only. Pin api_base to the global host with locations/eu => served by Gemini 3, processed in EU. Verified locally (returns output, no 404). Helper renders LLM__*__API_BASE only when set; prod/testing unchanged (still 2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)