### PR TITLE
fix(agent): drop missing GEMINI_API_KEY secret ref; Vertex Gemini env

### DIFF
--- a/helm/echo/templates/deployment-agent.yaml
+++ b/helm/echo/templates/deployment-agent.yaml
@@ -35,11 +35,6 @@ spec:
             - containerPort: {{ .Values.agent.service.port }}
               name: http
           env:
-            - name: GEMINI_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: echo-backend-secrets
-                  key: GEMINI_API_KEY
             - name: GCP_SA_JSON
               valueFrom:
                 secretKeyRef:

--- a/helm/echo/values.yaml
+++ b/helm/echo/values.yaml
@@ -89,8 +89,10 @@ agent:
       memory: "1Gi"
   env:
     ECHO_API_URL: "http://echo-api:8000/api"
-    LLM_MODEL: "claude-opus-4-6"
-    VERTEX_LOCATION: "europe-west1"
+    LLM_MODEL: "gemini-3.5-flash"
+    VERTEX_LOCATION: "eu"
+    # Gemini 3.x is global-host only; locations/eu stays in the request path.
+    VERTEX_API_ENDPOINT: "aiplatform.googleapis.com"
     AGENT_GRAPH_RECURSION_LIMIT: "80"
     AGENT_CORS_ORIGINS: "https://dashboard.echo-next.dembrane.com,https://portal.echo-next.dembrane.com,http://localhost:5173,http://localhost:5174"
 


### PR DESCRIPTION
Companion to Dembrane/echo agent model swap. Removes the secret ref whose key doesn't exist (CreateContainerConfigError on echo-next) and aligns model env with the agent code (gemini-3.5-flash, eu, global Vertex host). Merge after the app PR so the new image exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)