### PR TITLE
revert: restore DISABLE_REDACTION + ENABLE_CHAT_AUTO_SELECT env (prod outage)

### DIFF
--- a/helm/echo/values-prod.yaml
+++ b/helm/echo/values-prod.yaml
@@ -12,11 +12,13 @@ common:
     PARTICIPANT_BASE_URL: "https://portal.dembrane.com"
     API_BASE_URL: "https://api.dembrane.com/api"
     DISABLE_CORS: "0"
+    DISABLE_REDACTION: "1"
     DISABLE_SENTRY: "0"
     SERVE_API_DOCS: "0"
 
     # Feature flags
     TRANSCRIPTION_PROVIDER: "Dembrane-25-09"
+    FEATURE_FLAGS__ENABLE_CHAT_AUTO_SELECT: "0"
     FEATURE_FLAGS__ENABLE_CHAT_SELECT_ALL: "1"
     FEATURE_FLAGS__ENABLE_WEBHOOKS: "1"
 

--- a/helm/echo/values-testing.yaml
+++ b/helm/echo/values-testing.yaml
@@ -13,11 +13,13 @@ common:
     API_BASE_URL: "https://api.echo-testing.dembrane.com/api"
     AGENT_SERVICE_URL: "http://echo-agent:8001"
     DISABLE_CORS: "0"
+    DISABLE_REDACTION: "1"
     DISABLE_SENTRY: "0"
     SERVE_API_DOCS: "1"
 
     # Feature flags (same as dev)
     TRANSCRIPTION_PROVIDER: "Dembrane-25-09"
+    FEATURE_FLAGS__ENABLE_CHAT_AUTO_SELECT: "0"
     FEATURE_FLAGS__ENABLE_CHAT_SELECT_ALL: "1"
     FEATURE_FLAGS__ENABLE_WEBHOOKS: "1"
 

--- a/helm/echo/values.yaml
+++ b/helm/echo/values.yaml
@@ -13,6 +13,7 @@ common:
     API_BASE_URL: "https://api.echo-next.dembrane.com/api"
     AGENT_SERVICE_URL: "http://echo-agent:8001"
     DISABLE_CORS: "0"
+    DISABLE_REDACTION: "1"
     DISABLE_SENTRY: "0"
     SERVE_API_DOCS: "1"
 
@@ -24,6 +25,7 @@ common:
 
     # Feature flags
     TRANSCRIPTION_PROVIDER: "Dembrane-25-09"
+    FEATURE_FLAGS__ENABLE_CHAT_AUTO_SELECT: "0"
     FEATURE_FLAGS__ENABLE_CHAT_SELECT_ALL: "1"
     FEATURE_FLAGS__ENABLE_WEBHOOKS: "1"
 


### PR DESCRIPTION
Reverts #30. The deployed prod release (1e0362e1 / v2.0.5) still has these as REQUIRED fields in FeatureFlagSettings; the code that removes them is on main but has not shipped to prod (prod deploys on release tags, gitops config syncs immediately via Argo). Removing the env crashed all prod workers + scheduler + the new API replicaset on settings validation (bool_parsing on ''), halting transcription from ~09:00 UTC. Restoring the env unbreaks the deployed code; safe for echo-next since FeatureFlagSettings ignores unknown env.

Re-remove only after the code change reaches a prod release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)