### PR TITLE
echo-next: DOCS_BASE_URL for agent doc citations

### DIFF
--- a/helm/echo/values-echo-next.yaml
+++ b/helm/echo/values-echo-next.yaml
@@ -16,6 +16,13 @@
 # The api_base hardcodes project + model because litellm appends ":generateContent"
 # to it verbatim. This file is echo-next-only, so the dembrane-echo project is correct.
 # The _2/_3 regional failovers stay disabled (3.5 Flash is global-host only).
+# Published docs site for this env (GitHub Pages from dembrane/echo main,
+# .github/workflows/dev-deploy-docs.yml). The agent uses it to cite docs as
+# links. Prod stays unset until docs.dembrane.com serves the same corpus.
+agent:
+  env:
+    DOCS_BASE_URL: "https://docs.echo-next.dembrane.com"
+
 common:
   env:
     LLM__MULTI_MODAL_PRO__MODEL: "vertex_ai/gemini-3.5-flash"


### PR DESCRIPTION
Points the echo-next agent at the published docs site (https://docs.echo-next.dembrane.com, GitHub Pages from dembrane/echo main via Dembrane/echo#781) so chat cites docs as links instead of bare paths.

echo-next only (values-echo-next.yaml overlay); prod stays unset until docs.dembrane.com serves the same corpus. Additive env var, merges into the base agent.env map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)